### PR TITLE
Add Yaml config files to run the sequence

### DIFF
--- a/alphatwirl_interface/config/__init__.py
+++ b/alphatwirl_interface/config/__init__.py
@@ -1,6 +1,7 @@
-import base_stage
-import binned_df_stage
-import cutflow_stage
+from __future__ import absolute_import
+from . import base_stage
+from . import binned_df_stage
+from . import cutflow_stage
 
 
 __all__ = ["read_yaml"]

--- a/alphatwirl_interface/config/__init__.py
+++ b/alphatwirl_interface/config/__init__.py
@@ -1,0 +1,21 @@
+import base_stage
+import binned_df_stage
+import cutflow_stage
+import os
+
+
+__all__ = ["read_yaml"]
+
+
+from .dict_config import Sequence
+
+
+def read_yaml(cfg_filename, output_dir=None):
+    import yaml
+    with open(cfg_filename, "r") as infile:
+        cfg = yaml.load(infile)
+    if output_dir:
+        dict_cfg["output_dir"] = output_dir
+
+    sequence = Sequence(**dict_cfg)
+    return sequence.to_reader_collector_pairs()

--- a/alphatwirl_interface/config/__init__.py
+++ b/alphatwirl_interface/config/__init__.py
@@ -1,21 +1,21 @@
 import base_stage
 import binned_df_stage
 import cutflow_stage
-import os
 
 
 __all__ = ["read_yaml"]
 
 
-from .dict_config import Sequence
+from .dict_config import sequence_from_dict
 
 
 def read_yaml(cfg_filename, output_dir=None):
     import yaml
     with open(cfg_filename, "r") as infile:
         cfg = yaml.load(infile)
-    if output_dir:
-        dict_cfg["output_dir"] = output_dir
 
-    sequence = Sequence(**dict_cfg)
-    return sequence.to_reader_collector_pairs()
+    # Override the output_dir in the config file if this function is given one
+    if output_dir:
+        cfg["output_dir"] = output_dir
+
+    return sequence_from_dict(**cfg)

--- a/alphatwirl_interface/config/base_stage.py
+++ b/alphatwirl_interface/config/base_stage.py
@@ -1,0 +1,24 @@
+class BaseStage(object):
+    def __init__(self, name, output_directory, after=None):
+        self.__name = name
+        self.__output_dir = output_directory
+        if after is not None:
+            raise NotImplementedError("The `after` keyword is not yet supported for stages")
+
+    @property
+    def name(self):
+        return self.__name
+
+    @property
+    def output_dir(self):
+        return self.__output_dir
+
+    def apply_description(self, **args):
+        raise NotImplementedError
+
+    def as_rc_pairs(self):
+        """
+        Convert this stage to a list of reader collector pairs
+        returns: a list of reader-collector pairs
+        """
+        raise NotImplementedError

--- a/alphatwirl_interface/config/binned_df_stage.py
+++ b/alphatwirl_interface/config/binned_df_stage.py
@@ -1,0 +1,126 @@
+from __future__ import absolute_import
+import copy
+import six
+import numpy as np
+from .base_stage import BaseStage
+from .config_exceptions import BadAlphaTwirlInterfaceConfig
+
+
+from alphatwirl.configure import TableConfigCompleter, TableFileNameComposer
+from alphatwirl_interface.completions import complete
+from alphatwirl.binning import Binning, Echo
+
+
+__all__ = ["BinnedDataframe"]
+
+
+class BadBinnedDataframeConfig(BadAlphaTwirlInterfaceConfig):
+    pass
+
+
+class BinnedDataframe(BaseStage):
+    def apply_description(self, binning, weights=None):
+        self._binning = _create_binning_list(self.name, binning)
+        self._weights = _create_weights(weights)
+
+    def as_rc_pairs(self):
+        if not hasattr(self, "_reader_collector_pair"):
+            self._reader_collector_pair = self._create_rc_pairs()
+        return self._reader_collector_pair
+
+    def _create_rc_pairs(self):
+        keyAttrNames, keyOutColumnNames, binnings, keyIndices = zip(*self._binning)
+        if not any(keyIndices):
+            keyIndices = None
+        base_cfg = dict(keyAttrNames=keyAttrNames,
+                        keyOutColumnNames=keyOutColumnNames,
+                        binnings=binnings,
+                        keyIndices=keyIndices
+                       )
+
+        df_configs = {}
+        if not self._weights:
+            name_composer = TableFileNameComposer()
+            df_configs["unweighted"] = base_cfg
+        else:
+            for name, weights in self._weights.items():
+                config = copy.copy(base_cfg)
+                if weights != 1:
+                    config["weight"] = weights
+                df_configs[name] = config
+
+            name_composer = WithInsertTableFileNameComposer(TableFileNameComposer(), df_configs.keys())
+            tableConfigCompleter = TableConfigCompleter(createOutFileName=name_composer, defaultOutDir=self.output_dir)
+
+        return complete(df_configs.values(), tableConfigCompleter)
+
+
+def _create_binning_list(stage_name, bin_list):
+    if not isinstance(bin_list, list):
+        raise BadBinnedDataframeConfig("binning section for stage '{}' not a list".format(stage_name))
+    binning = []
+    for i, one_bin_dimension in enumerate(bin_list):
+        if not isinstance(one_bin_dimension, dict):
+            raise BadBinnedDataframeConfig("binning item no. {} is not a dictionary".format(i))
+        cleaned_dimension_dict = {"_" + k: v for k, v in one_bin_dimension.items()}
+        binning.append(_create_one_dimension(stage_name, **cleaned_dimension_dict))
+    return binning
+
+
+def _create_one_dimension(stage_name, _in, _out, _bins=None, _index=None):
+    if not isinstance(_in, six.string_types):
+        msg = "{}: binning dictionary contains non-string value for 'in'"
+        raise BadBinnedDataframeConfig(msg.format(stage_name))
+    if not isinstance(_out, six.string_types):
+        msg = "{}: binning dictionary contains non-string value for 'out'"
+        raise BadBinnedDataframeConfig(msg.format(stage_name))
+    if _index and not isinstance(_index, six.string_types):
+        msg = "{}: binning dictionary contains non-string and non-integer value for 'index'"
+        raise BadBinnedDataframeConfig(msg.format(stage_name))
+
+    if _bins is None:
+        bin_obj = Echo(nextFunc=None)
+    elif isinstance(_bins, dict):
+        # - bins: {nbins: 6 , low: 1  , high: 5 , overflow: True}
+        # - bins: {edges: [0, 200., 900], overflow: True}
+        if "nbins" in _bins and "low" in _bins and "high" in _bins:
+            low = _bins["low"]
+            high = _bins["high"]
+            nbins = _bins["nbins"]
+            edges = np.linspace(low, high, nbins + 1)
+        elif "edges" in _bins:
+            edges = _bins["edges"]
+        else:
+            msg = "{}: No way to infer binning edges for in={}"
+            raise BadBinnedDataframeConfig(msg.format(stage_name, _in))
+        bin_obj = Binning(boundaries=edges)
+    else:
+        msg = "{}: bins is neither None nor a dictionary for in={}"
+        raise BadBinnedDataframeConfig(msg.format(stage_name, _in))
+
+    return (str(_in), str(_out), bin_obj, _index)
+
+
+def _create_weights(weights):
+    if weights is None:
+        return None
+    if isinstance(weights, list):
+        return {str(w): w for w in weights}
+    elif isinstance(weights, dict):
+            return weights
+    # else we've got a single, scalar value
+    return {"weighted": weights}
+
+
+class WithInsertTableFileNameComposer():
+    def __init__(self, composer, inserts):
+        self.inserts = inserts
+        self.composer = composer
+        self.frame_idx = 0
+
+    def __call__(self, columnNames, indices, **kwargs):
+        this_insert = self.inserts[self.frame_idx]
+        suffix = kwargs.get("suffix", self.composer.default_suffix)
+        kwargs["suffix"] = "--{}.{}".format(this_insert, suffix)
+        self.frame_idx += 1
+        return self.composer(columnNames, **kwargs)

--- a/alphatwirl_interface/config/binned_df_stage.py
+++ b/alphatwirl_interface/config/binned_df_stage.py
@@ -35,8 +35,7 @@ class BinnedDataframe(BaseStage):
         base_cfg = dict(keyAttrNames=keyAttrNames,
                         keyOutColumnNames=keyOutColumnNames,
                         binnings=binnings,
-                        keyIndices=keyIndices
-                       )
+                        keyIndices=keyIndices)
 
         df_configs = {}
         if not self._weights:

--- a/alphatwirl_interface/config/binned_df_stage.py
+++ b/alphatwirl_interface/config/binned_df_stage.py
@@ -49,7 +49,7 @@ class BinnedDataframe(BaseStage):
                     config["weight"] = weights
                 df_configs[name] = config
 
-            name_composer = WithInsertTableFileNameComposer(TableFileNameComposer(), df_configs.keys())
+            name_composer = WithInsertTableFileNameComposer(TableFileNameComposer(), list(df_configs.keys()))
         tableConfigCompleter = TableConfigCompleter(createOutFileName=name_composer, defaultOutDir=self.output_dir)
 
         return complete(df_configs.values(), tableConfigCompleter)

--- a/alphatwirl_interface/config/binned_df_stage.py
+++ b/alphatwirl_interface/config/binned_df_stage.py
@@ -50,7 +50,7 @@ class BinnedDataframe(BaseStage):
                 df_configs[name] = config
 
             name_composer = WithInsertTableFileNameComposer(TableFileNameComposer(), df_configs.keys())
-            tableConfigCompleter = TableConfigCompleter(createOutFileName=name_composer, defaultOutDir=self.output_dir)
+        tableConfigCompleter = TableConfigCompleter(createOutFileName=name_composer, defaultOutDir=self.output_dir)
 
         return complete(df_configs.values(), tableConfigCompleter)
 

--- a/alphatwirl_interface/config/config_exceptions.py
+++ b/alphatwirl_interface/config/config_exceptions.py
@@ -1,0 +1,5 @@
+__all__ = ["BadAlphaTwirlInterfaceConfig"]
+
+
+class BadAlphaTwirlInterfaceConfig(Exception):
+    pass

--- a/alphatwirl_interface/config/cutflow_stage.py
+++ b/alphatwirl_interface/config/cutflow_stage.py
@@ -1,0 +1,112 @@
+from __future__ import absolute_import
+import re
+import six
+import numpy as np
+from .base_stage import BaseStage
+from .config_exceptions import BadAlphaTwirlInterfaceConfig
+
+
+__all__ = ["BinnedDataframe"]
+
+
+class BadCutflowConfig(BadAlphaTwirlInterfaceConfig):
+    pass
+
+
+class BadSelectionFile(BadAlphaTwirlInterfaceConfig):
+    pass
+
+
+class MultipleWeightedSelectionsNotImplemented(UserWarning):
+    pass
+
+
+class CutFlow(BaseStage):
+    output_filename = "cut_flow.txt"
+    def apply_description(self, selection_file=None, selection=None, aliases=None,
+                          lambda_arg="ev", counter=True, counter_weights=None):
+        if not selection and not selection_file:
+            raise BadCutflowConfig("{}: Neither selection nor selection_file specified".format(self.name))
+        if selection and selection_file:
+            raise BadCutflowConfig("{}: Both selection and selection_file given. Choose one!".format(self.name))
+
+        if selection_file:
+            selection, aliases = self._load_selection_file(selection_file)
+        self.selection = self._prepare_selection(self.name, selection, lambda_arg, aliases)
+
+        self._weights = _create_weights(weights)
+
+    def as_rc_pairs(self):
+        if hasattr(self, "_reader_collector_pair"):
+            self._reader_collector_pair = self._create_rc_pairs()
+        return self._reader_collector_pair
+
+    def _create_rc_pairs(self):
+        return [Selection(self.selection, os.path.join(self.output_dir, self.output_filename))]
+
+
+def _load_selection_file(selection_file):
+    import yaml
+    with open(selection_file, "r") as infile:
+        cfg = yaml.load(infile)
+    if "selection" not in cfg:
+        raise BadSelectionFile("No `selection` section in selection file '{}'".format(selection_file))
+    selection = cfg.pop("selection")
+    aliases = cfg.pop("aliases", None)
+    if cfg:
+        raise BadSelectionFile("Unknown sections in selection file '{}': {}".format(selection_file, cfg.keys()))
+    return selection, aliases
+
+
+def _prepare_selection(stage_name, selection, lambda_arg="ev", aliases=None):
+    # Despite how much we've heard about alphatwirl using dependency injection,
+    # the alphatwirl.selection.build_selection method doesn't presently allow
+    # me to inject a custom FactoryDispatcher, so we need to pre-process the
+    # dictionaries instead
+
+    if aliases and not isinstance(aliases, dict):
+        raise BadCutflowConfig("{}: aliases is not a dictionary".format(stage_name))
+    if isinstance(selection, dict):
+        selection = _recurse_selection(stage_name, selection, lambda_arg, aliases)
+    return selection
+
+
+def _recurse_selection(stage_name, selection, lambda_arg="ev", aliases=None):
+    if isinstance(selection, dict):
+        tidied_selection = {}
+        for key, value in selection.items():
+            if key not in ("All", "Any", "Not"):
+                tidied_selection[key] = value
+                continue
+            tidied_selection[key] = _recurse_selection(stage_name, value, lambda_arg, aliases)
+    elif isinstance(selection, (list, tuple)):
+        tidied_selection = [_recurse_selection(stage_name, element, lambda_arg, aliases) for element in selection]
+    else:
+        # Assume something scalar (string, bool, int), etc
+        tidied_selection = _process_single_selection(stage_name, selection, lambda_arg, aliases)
+    return tidied_selection
+
+
+def _process_single_selection(stage_name, selection, lambda_arg="ev", aliases=None):
+    if aliases:
+        # Get the alias if there is one else returns the original selection unchanged
+        selection = aliases.get(selection, selection)
+
+    if not isinstance(selection, six.string_types):
+        # Might sometimes be given other things, like bools, etc
+        return str(selection)
+    elif re.match(selection, "{}\s*\.".format(lambda_arg)):
+        return "{}: {}".format(lambda_arg, selection)
+
+    raise BadCutflowConfig("{}: Issue pre-processing selection '{}'".format(stage_name, selection))
+
+
+def _create_weights(stage_name, weights):
+    if weights is None or isinstance(weights, six.string_types):
+        return weights
+
+    if isinstance(weights, (tuple, list)):
+        if len(weights) != 1:
+            raise MultipleWeightedSelectionsNotImplemented("{}: Sorry!  We'll add this soon...".format(stage_name))
+        return weights[0]
+    raise BadCutflowConfig("{}: Cannot process weight specification".format(stage_name))

--- a/alphatwirl_interface/config/cutflow_stage.py
+++ b/alphatwirl_interface/config/cutflow_stage.py
@@ -31,10 +31,10 @@ class CutFlow(BaseStage):
             raise BadCutflowConfig("{}: Both selection and selection_file given. Choose one!".format(self.name))
 
         if selection_file:
-            selection, aliases = self._load_selection_file(selection_file)
-        self.selection = self._prepare_selection(self.name, selection, lambda_arg, aliases)
+            selection, aliases = _load_selection_file(self.name, selection_file)
+        self.selection = _prepare_selection(self.name, selection, lambda_arg, aliases)
 
-        self._weights = _create_weights(weights)
+        self._weights = _create_weights(self.name, counter_weights)
 
     def as_rc_pairs(self):
         if hasattr(self, "_reader_collector_pair"):
@@ -45,16 +45,18 @@ class CutFlow(BaseStage):
         return [Selection(self.selection, os.path.join(self.output_dir, self.output_filename))]
 
 
-def _load_selection_file(selection_file):
+def _load_selection_file(stage_name, selection_file):
     import yaml
     with open(selection_file, "r") as infile:
         cfg = yaml.load(infile)
     if "selection" not in cfg:
-        raise BadSelectionFile("No `selection` section in selection file '{}'".format(selection_file))
+        msg = "{}: No `selection` section in selection file '{}'"
+        raise BadSelectionFile(msg.format(stage_name, selection_file))
     selection = cfg.pop("selection")
     aliases = cfg.pop("aliases", None)
     if cfg:
-        raise BadSelectionFile("Unknown sections in selection file '{}': {}".format(selection_file, cfg.keys()))
+        msg = "{}: Unknown sections in selection file '{}': {}"
+        raise BadSelectionFile(msg.format(stage_name, selection_file, cfg.keys()))
     return selection, aliases
 
 

--- a/alphatwirl_interface/config/cutflow_stage.py
+++ b/alphatwirl_interface/config/cutflow_stage.py
@@ -8,7 +8,7 @@ from .config_exceptions import BadAlphaTwirlInterfaceConfig
 from ..selection import Selection
 
 
-__all__ = ["BinnedDataframe"]
+__all__ = ["CutFlow"]
 
 
 class BadCutflowConfig(BadAlphaTwirlInterfaceConfig):
@@ -25,6 +25,7 @@ class MultipleWeightedSelectionsNotImplemented(UserWarning):
 
 class CutFlow(BaseStage):
     output_filename = "cut_flow.txt"
+
     def apply_description(self, selection_file=None, selection=None, aliases=None,
                           lambda_arg="ev", counter=True, counter_weights=None):
         if not selection and not selection_file:

--- a/alphatwirl_interface/config/cutflow_stage.py
+++ b/alphatwirl_interface/config/cutflow_stage.py
@@ -37,7 +37,9 @@ class CutFlow(BaseStage):
             selection, aliases = _load_selection_file(self.name, selection_file)
         self.selection = _prepare_selection(self.name, selection, lambda_arg, aliases)
 
-        self._weights = _create_weights(self.name, counter_weights)
+        self._counter = counter
+        if self._counter:
+            self._weights = _create_weights(self.name, counter_weights)
 
     def as_rc_pairs(self):
         if not hasattr(self, "_reader_collector_pair"):
@@ -45,7 +47,11 @@ class CutFlow(BaseStage):
         return self._reader_collector_pair
 
     def _create_rc_pairs(self):
-        return [Selection(self.selection, os.path.join(self.output_dir, self.output_filename))]
+        if self._counter:
+            out_file = os.path.join(self.output_dir, self.output_filename)
+            return [Selection(self.selection, out_file)]
+        else:
+            return [Selection(self.selection)]
 
 
 def _load_selection_file(stage_name, selection_file):

--- a/alphatwirl_interface/config/cutflow_stage.py
+++ b/alphatwirl_interface/config/cutflow_stage.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
 import re
 import six
+import os
 import numpy as np
 from .base_stage import BaseStage
 from .config_exceptions import BadAlphaTwirlInterfaceConfig
+from ..selection import Selection
 
 
 __all__ = ["BinnedDataframe"]
@@ -37,7 +39,7 @@ class CutFlow(BaseStage):
         self._weights = _create_weights(self.name, counter_weights)
 
     def as_rc_pairs(self):
-        if hasattr(self, "_reader_collector_pair"):
+        if not hasattr(self, "_reader_collector_pair"):
             self._reader_collector_pair = self._create_rc_pairs()
         return self._reader_collector_pair
 

--- a/alphatwirl_interface/config/cutflow_stage.py
+++ b/alphatwirl_interface/config/cutflow_stage.py
@@ -95,8 +95,10 @@ def _process_single_selection(stage_name, selection, lambda_arg="ev", aliases=No
     if not isinstance(selection, six.string_types):
         # Might sometimes be given other things, like bools, etc
         return str(selection)
-    elif re.match(selection, "{}\s*\.".format(lambda_arg)):
-        return "{}: {}".format(lambda_arg, selection)
+    else:
+        regex = r"{}\s*\.".format(lambda_arg)
+        if re.search(regex, selection):
+            return "{}: {}".format(lambda_arg, selection)
 
     raise BadCutflowConfig("{}: Issue pre-processing selection '{}'".format(stage_name, selection))
 

--- a/alphatwirl_interface/config/cutflow_stage.py
+++ b/alphatwirl_interface/config/cutflow_stage.py
@@ -41,7 +41,7 @@ class CutFlow(BaseStage):
         self._weights = None
         self._weight_name = ""
         if self._counter:
-            self._weights, self._weight_name  = _create_weights(self.name, counter_weights)
+            self._weights, self._weight_name = _create_weights(self.name, counter_weights)
 
     def as_rc_pairs(self):
         if not hasattr(self, "_reader_collector_pair"):

--- a/alphatwirl_interface/config/dict_config.py
+++ b/alphatwirl_interface/config/dict_config.py
@@ -1,0 +1,74 @@
+from __future__ import absolute_import
+import six
+import collections
+#import base_stage
+from .base_stage import BaseStage
+from .config_exceptions import BadAlphaTwirlInterfaceConfig
+import os
+import logging
+logger = logging.getLogger(__name__)
+
+
+__all__ = ["Sequence"]
+
+
+class BadStagesDescription(BadAlphaTwirlInterfaceConfig):
+    pass
+
+
+class Sequence():
+    def __init__(self, stages, output_dir=os.getcwd(), **stage_descriptions):
+        self.output_dir = output_dir
+        self.stages = self._create_stages(stages, self.output_dir)
+        self._configure_stages(self.stages, stage_descriptions)
+
+    @staticmethod
+    def _create_stages(self, stages, out_dir=os.getcwd()):
+        stages = [make_stage(i, out_dir, stage_cfg) for i, stage_cfg in enumerate(stages)]
+        stage_names = [stage.name for stage in stages]
+        return collections.OrderedDict(zip(stage_names, stages))
+
+    @staticmethod
+    def _configure_stages(self, stages, stage_descriptions):
+        for name, stage in stages.items():
+            cfg = stage_descriptions.get(name, None)
+            if not cfg:
+                raise BadStagesDescription("Missing description for stage '{}'".format(name))
+            elif not isinstance(cfg, dict):
+                raise BadStagesDescription("Description for stage '{}' is not a dictionary".format(name))
+            stage.apply_description(**cfg)
+
+    def validate(self):
+        raise NotImplementedError
+
+    def to_reader_collector_pairs(self):
+        pairs = []
+        for stage in self.stages:
+            pairs += stage.as_rc_pairs()
+        return pairs
+
+
+def make_stage(index, output_dir, stage_cfg, default_type="BinnedDataframe"):
+    if isinstance(stage_cfg, six.string_types):
+        return default_type(stage_cfg)
+    elif not isinstance(stage_cfg, dict):
+        msg = "Bad stage configuration, for stage {} in stages list".format(index)
+        logger.error(msg + "\n Each stage config must be either a single string or a dictionary")
+        raise BadStagesDescription(msg)
+
+    if len(stage_cfg) != 1:
+        msg = "More than one key in dictionary spec for stage {} in stages list".format(index)
+        logger.error(msg + "\n dictionary given: {}".format(stage_cfg))
+        raise BadStagesDescription(msg)
+    name, args = stage_cfg.items()[0]
+    stage_type = args.pop("type", default_type)
+
+    # Find the actual concrete class based on the string
+    stage_class = None
+    for subclass in BaseStage.__subclasses__():
+        if stage_type == subclass.__name__:
+            stage_class = subclass
+            break
+    if not stage_class:
+        raise BadStagesDescription("Unknown type for stage '{}': {}".format(name, stage_type))
+    return stage_class(name, output_dir, **args)

--- a/alphatwirl_interface/config/dict_config.py
+++ b/alphatwirl_interface/config/dict_config.py
@@ -50,7 +50,7 @@ def _make_stage(index, output_dir, stage_cfg, default_type="BinnedDataframe"):
             msg = "More than one key in dictionary spec for stage {} in stages list".format(index)
             logger.error(msg + "\n dictionary given: {}".format(stage_cfg))
             raise BadStagesDescription(msg)
-        name, args = stage_cfg.items()[0]
+        [(name, args)] = stage_cfg.items()
         stage_type = args.pop("type", default_type)
     else:
         msg = "Bad stage configuration, for stage {} in stages list".format(index)

--- a/alphatwirl_interface/config/dict_config.py
+++ b/alphatwirl_interface/config/dict_config.py
@@ -9,59 +9,55 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-__all__ = ["Sequence"]
+__all__ = ["sequence_from_dict"]
 
 
 class BadStagesDescription(BadAlphaTwirlInterfaceConfig):
     pass
 
 
-class Sequence():
-    def __init__(self, stages, output_dir=os.getcwd(), **stage_descriptions):
-        self.output_dir = output_dir
-        self.stages = self._create_stages(stages, self.output_dir)
-        self._configure_stages(self.stages, stage_descriptions)
+def sequence_from_dict(stages, output_dir=os.getcwd(), **stage_descriptions):
+    stages = _create_stages(stages, output_dir)
+    _configure_stages(stages, stage_descriptions)
 
-    @staticmethod
-    def _create_stages(self, stages, out_dir=os.getcwd()):
-        stages = [make_stage(i, out_dir, stage_cfg) for i, stage_cfg in enumerate(stages)]
-        stage_names = [stage.name for stage in stages]
-        return collections.OrderedDict(zip(stage_names, stages))
-
-    @staticmethod
-    def _configure_stages(self, stages, stage_descriptions):
-        for name, stage in stages.items():
-            cfg = stage_descriptions.get(name, None)
-            if not cfg:
-                raise BadStagesDescription("Missing description for stage '{}'".format(name))
-            elif not isinstance(cfg, dict):
-                raise BadStagesDescription("Description for stage '{}' is not a dictionary".format(name))
-            stage.apply_description(**cfg)
-
-    def validate(self):
-        raise NotImplementedError
-
-    def to_reader_collector_pairs(self):
-        pairs = []
-        for stage in self.stages:
-            pairs += stage.as_rc_pairs()
-        return pairs
+    pairs = []
+    for stage in stages:
+        pairs += stage.as_rc_pairs()
+    return pairs
 
 
-def make_stage(index, output_dir, stage_cfg, default_type="BinnedDataframe"):
+def _create_stages(stages, out_dir=os.getcwd()):
+    return [_make_stage(i, out_dir, stage_cfg) for i, stage_cfg in enumerate(stages)]
+
+
+def _configure_stages(stages, stage_descriptions):
+    for stage in stages:
+        name = stage.name
+        cfg = stage_descriptions.get(name, None)
+        if not cfg:
+            raise BadStagesDescription("Missing description for stage '{}'".format(name))
+        elif not isinstance(cfg, dict):
+            raise BadStagesDescription("Description for stage '{}' is not a dictionary".format(name))
+        stage.apply_description(**cfg)
+
+
+def _make_stage(index, output_dir, stage_cfg, default_type="BinnedDataframe"):
     if isinstance(stage_cfg, six.string_types):
-        return default_type(stage_cfg)
-    elif not isinstance(stage_cfg, dict):
+        stage_type = default_type
+        name = stage_cfg
+        args = {}
+    elif isinstance(stage_cfg, dict):
+        if len(stage_cfg) != 1:
+            msg = "More than one key in dictionary spec for stage {} in stages list".format(index)
+            logger.error(msg + "\n dictionary given: {}".format(stage_cfg))
+            raise BadStagesDescription(msg)
+        name, args = stage_cfg.items()[0]
+        stage_type = args.pop("type", default_type)
+    else:
         msg = "Bad stage configuration, for stage {} in stages list".format(index)
         logger.error(msg + "\n Each stage config must be either a single string or a dictionary")
         raise BadStagesDescription(msg)
 
-    if len(stage_cfg) != 1:
-        msg = "More than one key in dictionary spec for stage {} in stages list".format(index)
-        logger.error(msg + "\n dictionary given: {}".format(stage_cfg))
-        raise BadStagesDescription(msg)
-    name, args = stage_cfg.items()[0]
-    stage_type = args.pop("type", default_type)
 
     # Find the actual concrete class based on the string
     stage_class = None

--- a/alphatwirl_interface/config/dict_config.py
+++ b/alphatwirl_interface/config/dict_config.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 import six
 import collections
-#import base_stage
 from .base_stage import BaseStage
 from .config_exceptions import BadAlphaTwirlInterfaceConfig
 import os
@@ -57,7 +56,6 @@ def _make_stage(index, output_dir, stage_cfg, default_type="BinnedDataframe"):
         msg = "Bad stage configuration, for stage {} in stages list".format(index)
         logger.error(msg + "\n Each stage config must be either a single string or a dictionary")
         raise BadStagesDescription(msg)
-
 
     # Find the actual concrete class based on the string
     stage_class = None

--- a/alphatwirl_interface/cut_flows.py
+++ b/alphatwirl_interface/cut_flows.py
@@ -29,13 +29,18 @@ def cut_flow_with_counter(cut_flow, cut_flow_summary_filename):
     return [(eventSelection, collector)]
 
 
-def cut_flow_with_weighted_counter(cut_flow, cut_flow_summary_filename):
-    eventSelection = alphatwirl.selection.build_selection(
-        path_cfg=cut_flow,
-        AllClass=alphatwirl.selection.modules.AllwCountWeight,
-        AnyClass=alphatwirl.selection.modules.AnywCountWeight,
-        NotClass=alphatwirl.selection.modules.NotwCountWeight
-    )
+def cut_flow_with_weighted_counter(cut_flow, cut_flow_summary_filename, weight_attr="weight"):
+    from functools import partial
+
+    if weight_attr is None or weight_attr == 1:
+        eventSelection = _build_selection(cut_flow)
+    else:
+        eventSelection = alphatwirl.selection.build_selection(
+            path_cfg=cut_flow,
+            AllClass=alphatwirl.selection.modules.WeightedCountMaker("all", weight_attr),
+            AnyClass=alphatwirl.selection.modules.WeightedCountMaker("any", weight_attr),
+            NotClass=alphatwirl.selection.modules.WeightedCountMaker("not", weight_attr)
+        )
     resultsCombinationMethod = alphatwirl.collector.ToTupleListWithDatasetColumn(
         summaryColumnNames=('depth', 'class', 'name', 'pass', 'total')
     )
@@ -45,6 +50,11 @@ def cut_flow_with_weighted_counter(cut_flow, cut_flow_summary_filename):
 
 
 def cut_flow(cut_flow):
-    eventSelection = _build_selection(cut_flow)
+    eventSelection = alphatwirl.selection.build_selection(
+        path_cfg=cut_flow,
+        AllClass=alphatwirl.selection.modules.All,
+        AnyClass=alphatwirl.selection.modules.Any,
+        NotClass=alphatwirl.selection.modules.Not,
+    )
 
     return to_null_collector_pairs([eventSelection])

--- a/alphatwirl_interface/selection.py
+++ b/alphatwirl_interface/selection.py
@@ -1,9 +1,9 @@
 from collections import Sequence
-from alphatwirl_interface.cut_flows import cut_flow, cut_flow_with_counter
+from alphatwirl_interface.cut_flows import cut_flow, cut_flow_with_counter, cut_flow_with_weighted_counter
 import six
 
 
-def Selection(steps={}, cutflow_file=None):
+def Selection(steps={}, cutflow_file=None, weight_attr=None):
     '''
         This class ties together several modules from alphatwirl to
         bring a simplified Selection experience.
@@ -34,9 +34,10 @@ def Selection(steps={}, cutflow_file=None):
     '''
     rc_pair = None
     if cutflow_file:
-        rc_pair = cut_flow_with_counter(
-            steps, cutflow_file,
-        )
+        if weight_attr:
+            rc_pair = cut_flow_with_weighted_counter(steps, cutflow_file, weight_attr)
+        else:
+            rc_pair = cut_flow_with_counter(steps, cutflow_file)
     else:
         rc_pair = cut_flow(steps)
     return rc_pair[0]

--- a/alphatwirl_interface/weighters.py
+++ b/alphatwirl_interface/weighters.py
@@ -22,3 +22,47 @@ class WeightCalculatorProduct(object):
     def __call__(self, event):
         weights = [getattr(event, attr)[0] for attr in self.weight_list]
         return reduce(operator.mul, weights, 1)
+
+
+class WeightCalculatorSingleAttr(object):
+    """
+    return the a single event attribute as a weight
+    """
+
+    def __init__(self, attr, index=0):
+        self.weight_attr = attr
+        self.index = index
+
+    def __repr__(self):
+        name_value_pairs = (
+            ('weight_attr', self.weight_attr),
+            ('index', self.index),
+        )
+        return '{}({})'.format(
+            self.__class__.__name__,
+            ', '.join(['{} = {!r}'.format(n, v) for n, v in name_value_pairs]),
+        )
+
+    def __call__(self, event):
+        return getattr(event, self.weight_attr)[self.index]
+
+
+class WeightCalculatorConst(object):
+    """
+    return a constant value as a weight
+    """
+
+    def __init__(self, weight):
+        self.weight = weight
+
+    def __repr__(self):
+        name_value_pairs = (
+            ('weight', self.weight),
+        )
+        return '{}({})'.format(
+            self.__class__.__name__,
+            ', '.join(['{} = {!r}'.format(n, v) for n, v in name_value_pairs]),
+        )
+
+    def __call__(self, event):
+        return self.weight

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -2,6 +2,6 @@
 export PYTHONPATH=$PWD:$PYTHONPATH
 # get alphatwirl from master branch
 pip install -U git+https://github.com/benkrikler/alphatwirl.git \
-  flake8
+  flake8 pyyaml
 
 make install

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -2,6 +2,6 @@
 export PYTHONPATH=$PWD:$PYTHONPATH
 # get alphatwirl from master branch
 pip install -U git+https://github.com/benkrikler/alphatwirl.git \
-  flake8 pyyaml
+  flake8 pyyaml pandas
 
 make install

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 export PYTHONPATH=$PWD:$PYTHONPATH
 # get alphatwirl from master branch
-pip install -U git+https://github.com/alphatwirl/alphatwirl.git \
+pip install -U git+https://github.com/benkrikler/alphatwirl.git \
   flake8
 
 make install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 nose2
+yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 nose2
-yaml

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup_requirements = [
 test_requirements = [
     'flake8',
     'pytest',
+    'yaml',
     # TODO: put package test requirements here
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ test_requirements = [
     'flake8',
     'pytest',
     'pyyaml',
+    'pandas',
     # TODO: put package test requirements here
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup_requirements = [
 test_requirements = [
     'flake8',
     'pytest',
-    'yaml',
+    'pyyaml',
     # TODO: put package test requirements here
 ]
 

--- a/test/config/test_base_stage.py
+++ b/test/config/test_base_stage.py
@@ -1,0 +1,31 @@
+import pytest
+import alphatwirl_interface.config.base_stage as base_stage
+
+
+@pytest.fixture
+def base_1():
+    return base_stage.BaseStage("base_1", "some/out/directory")
+
+
+def test_BaseStage(base_1):
+    assert base_1.name == "base_1"
+    assert base_1.output_dir == "some/out/directory"
+    with pytest.raises(AttributeError) as ex:
+        base_1.name = "hello"
+    assert "can't set attribute" in str(ex)
+
+    with pytest.raises(AttributeError) as ex:
+        base_1.output_dir = "hello"
+    assert "can't set attribute" in str(ex)
+
+
+
+def test_apply_description_raises(base_1):
+    some_cfg = dict(selection="junk", something_else=True)
+    with pytest.raises(NotImplementedError):
+        base_1.apply_description(**some_cfg)
+
+
+def test_as_rc_pairs_raises(base_1):
+    with pytest.raises(NotImplementedError):
+        base_1.as_rc_pairs()

--- a/test/config/test_base_stage.py
+++ b/test/config/test_base_stage.py
@@ -19,7 +19,6 @@ def test_BaseStage(base_1):
     assert "can't set attribute" in str(ex)
 
 
-
 def test_apply_description_raises(base_1):
     some_cfg = dict(selection="junk", something_else=True)
     with pytest.raises(NotImplementedError):

--- a/test/config/test_binned_df_stage.py
+++ b/test/config/test_binned_df_stage.py
@@ -6,6 +6,7 @@ from alphatwirl.loop import Collector
 
 from alphatwirl_interface.weighters import WeightCalculatorSingleAttr, WeightCalculatorConst
 
+
 @pytest.fixture
 def bins_alphaT():
     return {"in": "AlphaT", "out": "alphaT", "bins": dict(nbins=10, low=0, high=2.5)}

--- a/test/config/test_binned_df_stage.py
+++ b/test/config/test_binned_df_stage.py
@@ -105,22 +105,39 @@ def test_BinnedDataframe(binned_df_1, tmpdir):
     assert binned_df_1.output_dir == str(tmpdir)
 
 
-def test_BinnedDataframe_apply_description_1(binned_df_1, config_1):
+@pytest.fixture
+def binned_df_1_configured_1(binned_df_1, config_1):
     binned_df_1.apply_description(**config_1)
-    assert len(binned_df_1._binning) == 2
-    assert len(binned_df_1._binning[0]) == 4
-    assert len(binned_df_1._weights) == 2
+    return binned_df_1
 
 
-def test_BinnedDataframe_apply_description_2(binned_df_1, config_2):
+@pytest.fixture
+def binned_df_1_configured_2(binned_df_1, config_2):
     binned_df_1.apply_description(**config_2)
-    assert len(binned_df_1._binning) == 3
-    assert len(binned_df_1._binning[0]) == 4
-    assert len(binned_df_1._weights) == 2
+    return binned_df_1
 
 
-def test_BinnedDataframe_as_rc_pairs(binned_df_1, config_1):
-    binned_df_1.apply_description(**config_1)
-    rc_pairs = binned_df_1.as_rc_pairs()
-    assert len(rc_pairs) == len(config_1["weights"])
+def test_BinnedDataframe_apply_description_1(binned_df_1_configured_1):
+    assert len(binned_df_1_configured_1._binning) == 2
+    assert len(binned_df_1_configured_1._binning[0]) == 4
+    assert len(binned_df_1_configured_1._weights) == 2
+
+
+def test_BinnedDataframe_apply_description_2(binned_df_1_configured_2):
+    assert len(binned_df_1_configured_2._binning) == 3
+    assert len(binned_df_1_configured_2._binning[0]) == 4
+    assert len(binned_df_1_configured_2._weights) == 2
+
+
+def test_BinnedDataframe_as_rc_pairs_1(binned_df_1_configured_1):
+    rc_pairs = binned_df_1_configured_1.as_rc_pairs()
+    assert isinstance(rc_pairs, list)
+    assert len(rc_pairs) == 2
+    assert all(map(lambda x: isinstance(x[0], Reader), rc_pairs))
+
+
+def test_BinnedDataframe_as_rc_pairs_2(binned_df_1_configured_2):
+    rc_pairs = binned_df_1_configured_2.as_rc_pairs()
+    assert isinstance(rc_pairs, list)
+    assert len(rc_pairs) == 2
     assert all(map(lambda x: isinstance(x[0], Reader), rc_pairs))

--- a/test/config/test_binned_df_stage.py
+++ b/test/config/test_binned_df_stage.py
@@ -100,8 +100,9 @@ def binned_df_1(tmpdir):
     return bdfs.BinnedDataframe("binned_df_1", str(tmpdir))
 
 
-def test_BinnedDataframe(binned_df_1):
+def test_BinnedDataframe(binned_df_1, tmpdir):
     assert binned_df_1.name == "binned_df_1"
+    assert binned_df_1.output_dir == str(tmpdir)
 
 
 def test_BinnedDataframe_apply_description_1(binned_df_1, config_1):

--- a/test/config/test_binned_df_stage.py
+++ b/test/config/test_binned_df_stage.py
@@ -4,6 +4,7 @@ from alphatwirl.binning import Binning, Echo
 from alphatwirl.summary import Reader
 from alphatwirl.loop import Collector
 
+from alphatwirl_interface.weighters import WeightCalculatorSingleAttr, WeightCalculatorConst
 
 @pytest.fixture
 def bins_alphaT():
@@ -68,22 +69,20 @@ def test__create_binning_list(bins_region, bins_alphaT):
     assert len(binning) == 2
 
 
-def test__create_weights(weight_list):
-    weights = bdfs._create_weights(weight_list)
-    weight_keys = list(weights.keys())
-    weight_values = list(weights.values())
+def test__create_weights_list(weight_list):
+    name = "test__create_weights_list"
+    weights = bdfs._create_weights(name, weight_list)
     assert len(weights) == 2
-    assert weight_keys[weight_values.index(1)] == "1"
-    assert weight_keys[weight_values.index("weight")] == "weight"
+    assert isinstance(weights["1"], WeightCalculatorConst)
+    assert isinstance(weights["weight"], WeightCalculatorSingleAttr)
 
 
-def test__create_weights(weight_dict):
-    weights = bdfs._create_weights(weight_dict)
-    weight_keys = list(weights.keys())
-    weight_values = list(weights.values())
+def test__create_weights_dict(weight_dict):
+    name = "test__create_weights_dict"
+    weights = bdfs._create_weights(name, weight_dict)
     assert len(weights) == 2
-    assert weight_keys[weight_values.index(1)] == "none"
-    assert weight_keys[weight_values.index("weight")] == "weighted"
+    assert isinstance(weights["none"], WeightCalculatorConst)
+    assert isinstance(weights["weighted"], WeightCalculatorSingleAttr)
 
 
 @pytest.fixture

--- a/test/config/test_binned_df_stage.py
+++ b/test/config/test_binned_df_stage.py
@@ -29,12 +29,13 @@ def weight_list():
 def weight_dict():
     return dict(none=1, weighted="weight")
 
+
 def test__create_one_region(bins_region):
     cfg = {"_" + k: v for k, v in bins_region.items()}
     _in, _out, _bins, _index = bdfs._create_one_dimension("test__create_one_region", **cfg)
     assert _in == "REGION"
     assert _out == "region"
-    assert _index == None
+    assert _index is None
     assert isinstance(_bins, Echo)
 
 
@@ -43,9 +44,9 @@ def test__create_one_dimension_aT(bins_alphaT):
     _in, _out, _bins, _index = bdfs._create_one_dimension("test__create_one_dimension_aT", **cfg)
     assert _in == "AlphaT"
     assert _out == "alphaT"
-    assert _index == None
+    assert _index is None
     assert isinstance(_bins, Binning)
-    assert _bins.boundaries == tuple([i/20. for i in range(0, 51, 5)])
+    assert _bins.boundaries == tuple([i / 20. for i in range(0, 51, 5)])
     assert _bins.underflow_bin == float("-inf")
     assert _bins.overflow_bin == 2.5
 

--- a/test/config/test_binned_df_stage.py
+++ b/test/config/test_binned_df_stage.py
@@ -1,0 +1,125 @@
+import pytest
+import alphatwirl_interface.config.binned_df_stage as bdfs
+from alphatwirl.binning import Binning, Echo
+from alphatwirl.summary import Reader
+from alphatwirl.loop import Collector
+
+
+@pytest.fixture
+def bins_alphaT():
+    return {"in": "AlphaT", "out": "alphaT", "bins": dict(nbins=10, low=0, high=2.5)}
+
+
+@pytest.fixture
+def bins_pt():
+    return {"in": "jet_pt", "out": "pt_leadJet", "bins": dict(edges=[0, 20., 100.], overflow=True), "index": 0}
+
+
+@pytest.fixture
+def bins_region():
+    return {"in": "REGION", "out": "region"}
+
+
+@pytest.fixture
+def weight_list():
+    return [1, "weight"]
+
+
+@pytest.fixture
+def weight_dict():
+    return dict(none=1, weighted="weight")
+
+def test__create_one_region(bins_region):
+    cfg = {"_" + k: v for k, v in bins_region.items()}
+    _in, _out, _bins, _index = bdfs._create_one_dimension("test__create_one_region", **cfg)
+    assert _in == "REGION"
+    assert _out == "region"
+    assert _index == None
+    assert isinstance(_bins, Echo)
+
+
+def test__create_one_dimension_aT(bins_alphaT):
+    cfg = {"_" + k: v for k, v in bins_alphaT.items()}
+    _in, _out, _bins, _index = bdfs._create_one_dimension("test__create_one_dimension_aT", **cfg)
+    assert _in == "AlphaT"
+    assert _out == "alphaT"
+    assert _index == None
+    assert isinstance(_bins, Binning)
+    assert _bins.boundaries == tuple([i/20. for i in range(0, 51, 5)])
+    assert _bins.underflow_bin == float("-inf")
+    assert _bins.overflow_bin == 2.5
+
+
+def test__create_one_dimension_HT(bins_pt):
+    cfg = {"_" + k: v for k, v in bins_pt.items()}
+    _in, _out, _bins, _index = bdfs._create_one_dimension("test__create_one_dimension_HT", **cfg)
+    assert _in == "jet_pt"
+    assert _out == "pt_leadJet"
+    assert _index == 0
+    assert isinstance(_bins, Binning)
+    assert _bins.boundaries == (0, 20., 100.)
+    assert _bins.underflow_bin == float("-inf")
+    assert _bins.overflow_bin == 100.
+
+
+def test__create_binning_list(bins_region, bins_alphaT):
+    binning = bdfs._create_binning_list("test__create_binning_list", [bins_region, bins_alphaT])
+    assert len(binning) == 2
+
+
+def test__create_weights(weight_list):
+    weights = bdfs._create_weights(weight_list)
+    weight_keys = list(weights.keys())
+    weight_values = list(weights.values())
+    assert len(weights) == 2
+    assert weight_keys[weight_values.index(1)] == "1"
+    assert weight_keys[weight_values.index("weight")] == "weight"
+
+
+def test__create_weights(weight_dict):
+    weights = bdfs._create_weights(weight_dict)
+    weight_keys = list(weights.keys())
+    weight_values = list(weights.values())
+    assert len(weights) == 2
+    assert weight_keys[weight_values.index(1)] == "none"
+    assert weight_keys[weight_values.index("weight")] == "weighted"
+
+
+@pytest.fixture
+def config_1(bins_alphaT, bins_pt, weight_list):
+    return dict(binning=[bins_alphaT, bins_pt], weights=weight_list)
+
+
+@pytest.fixture
+def config_2(bins_alphaT, bins_pt, bins_region, weight_dict):
+    return dict(binning=[bins_pt, bins_alphaT, bins_region], weights=weight_dict)
+
+
+@pytest.fixture
+def binned_df_1(tmpdir):
+    return bdfs.BinnedDataframe("binned_df_1", str(tmpdir))
+
+
+def test_BinnedDataframe(binned_df_1):
+    assert binned_df_1.name == "binned_df_1"
+
+
+def test_BinnedDataframe_apply_description_1(binned_df_1, config_1):
+    binned_df_1.apply_description(**config_1)
+    assert len(binned_df_1._binning) == 2
+    assert len(binned_df_1._binning[0]) == 4
+    assert len(binned_df_1._weights) == 2
+
+
+def test_BinnedDataframe_apply_description_2(binned_df_1, config_2):
+    binned_df_1.apply_description(**config_2)
+    assert len(binned_df_1._binning) == 3
+    assert len(binned_df_1._binning[0]) == 4
+    assert len(binned_df_1._weights) == 2
+
+
+def test_BinnedDataframe_as_rc_pairs(binned_df_1, config_1):
+    binned_df_1.apply_description(**config_1)
+    rc_pairs = binned_df_1.as_rc_pairs()
+    assert len(rc_pairs) == len(config_1["weights"])
+    assert all(map(lambda x: isinstance(x[0], Reader), rc_pairs))

--- a/test/config/test_cutflow_stage.py
+++ b/test/config/test_cutflow_stage.py
@@ -122,9 +122,10 @@ def test__load_selection_file_aliases(selection_file_alias):
 
 def test__create_weights():
     name = "test__create_weights"
-    assert cfs._create_weights(name, weights=None) is None
-    assert cfs._create_weights(name, weights="some_attribute") == "some_attribute"
-    assert cfs._create_weights(name, weights=["some_attribute"]) == "some_attribute"
+    assert cfs._create_weights(name, weights=None) == (1, "unweighted")
+    assert cfs._create_weights(name, weights="some_attribute") == ("some_attribute", "some_attribute")
+    assert cfs._create_weights(name, weights=["some_attribute"]) == ("some_attribute", "some_attribute")
+    assert cfs._create_weights(name, weights={"1": "one"}) == ("one", "1")
     with pytest.raises(cfs.MultipleWeightedSelectionsNotImplemented):
         cfs._create_weights(name, weights=["some", "attribute"])
 
@@ -171,11 +172,11 @@ def test_apply_description_raises(cutflow_1, selection_file, selection_dict_1):
 
 
 def test_as_rc_pairs(cutflow_1, selection_file):
-    from alphatwirl.selection.modules.with_count import AllwCount
+    from alphatwirl.selection.modules.with_count_weight import AllwCountWeight
     config = dict(selection_file=selection_file, aliases=dict(some_alias="ev.something == 1"),
                   counter_weights="an_attribrute")
     cutflow_1.apply_description(**config)
     rc_pairs = cutflow_1.as_rc_pairs()
     assert isinstance(rc_pairs, list)
     assert len(rc_pairs) == 1
-    assert isinstance(rc_pairs[0][0], AllwCount)
+    assert isinstance(rc_pairs[0][0], AllwCountWeight)

--- a/test/config/test_cutflow_stage.py
+++ b/test/config/test_cutflow_stage.py
@@ -1,0 +1,36 @@
+import pytest
+import alphatwirl_interface.config.cutflow_stage as cfs
+
+
+@pytest.fixture
+def selection_cut_1():
+    return "ev.jet_pt[0] > 0"
+
+@pytest.fixture
+def selection_cut_2():
+    return "ev.nJet > 1"
+
+
+@pytest.fixture
+def selection_dict_1(selection_cut_1):
+    return dict(All=[selection_cut_1, False])
+
+
+@pytest.fixture
+def selection_dict_2(selection_cut_1, selection_cut_2):
+    return dict(All=[selection_cut_1, dict(Any=[selection_cut_2, True])])
+
+
+@pytest.fixture
+def selection_dict_3(selection_cut_1, selection_cut_2):
+    return dict(All=[selection_cut_1, dict(Any=dict(Not=selection_cut_2))])
+
+
+#def test_apply_description(self, selection_file=None, selection=None, aliases=None,
+#def test_as_rc_pairs(self):
+#def test__create_rc_pairs(self):
+#def test__load_selection_file(selection_file):
+#def test__prepare_selection(stage_name, selection, lambda_arg="ev", aliases=None):
+#def test__recurse_selection(stage_name, selection, lambda_arg="ev", aliases=None):
+#def test__process_single_selection(stage_name, selection, lambda_arg="ev", aliases=None):
+#def test__create_weights(stage_name, weights):

--- a/test/config/test_cutflow_stage.py
+++ b/test/config/test_cutflow_stage.py
@@ -170,5 +170,12 @@ def test_apply_description_raises(cutflow_1, selection_file, selection_dict_1):
     assert "Neither selection nor selection_file" in str(ex)
 
 
-#def test_as_rc_pairs(self):
-#def test__create_rc_pairs(self):
+def test_as_rc_pairs(cutflow_1, selection_file):
+    from alphatwirl.selection.modules.with_count import AllwCount
+    config = dict(selection_file=selection_file, aliases=dict(some_alias="ev.something == 1"),
+                counter_weights="an_attribrute")
+    cutflow_1.apply_description(**config)
+    rc_pairs = cutflow_1.as_rc_pairs()
+    assert isinstance(rc_pairs, list)
+    assert len(rc_pairs) == 1
+    assert isinstance(rc_pairs[0][0], AllwCount)

--- a/test/config/test_cutflow_stage.py
+++ b/test/config/test_cutflow_stage.py
@@ -18,13 +18,13 @@ def selection_cut_alias():
 
 
 def test__process_single_selection_1(selection_cut_1):
-    out_selection = cfs._process_single_selection("test__process_single_selection", 
+    out_selection = cfs._process_single_selection("test__process_single_selection",
                                                   selection_cut_1, "ev")
     assert out_selection == "ev: ev.jet_pt[0] > 0"
 
 
 def test__process_single_selection_alias(selection_cut_alias):
-    aliases = dict(some_alias = "ev.something == 1")
+    aliases = dict(some_alias="ev.something == 1")
     out_selection = cfs._process_single_selection("test__process_single_selection_alias",
                                                   selection_cut_alias, "ev", aliases=aliases)
     assert out_selection == "ev: ev.something == 1"
@@ -33,7 +33,7 @@ def test__process_single_selection_alias(selection_cut_alias):
 def test__process_single_selection_raises(selection_cut_alias):
     name = "test__process_single_selection_raises"
     with pytest.raises(cfs.BadCutflowConfig) as ex:
-        out_selection = cfs._process_single_selection(name, selection_cut_alias, "ev", aliases={1:"blargwd"})
+        cfs._process_single_selection(name, selection_cut_alias, "ev", aliases={1: "blargwd"})
     assert "Issue pre-processing selection" in str(ex.value)
 
 
@@ -125,7 +125,7 @@ def test__create_weights():
     assert cfs._create_weights(name, weights=None) is None
     assert cfs._create_weights(name, weights="some_attribute") == "some_attribute"
     assert cfs._create_weights(name, weights=["some_attribute"]) == "some_attribute"
-    with pytest.raises(cfs.MultipleWeightedSelectionsNotImplemented) as ex:
+    with pytest.raises(cfs.MultipleWeightedSelectionsNotImplemented):
         cfs._create_weights(name, weights=["some", "attribute"])
 
 
@@ -141,7 +141,7 @@ def test_CutFlow(cutflow_1, tmpdir):
 
 def test_apply_description_1(cutflow_1, selection_dict_1):
     config = dict(selection=selection_dict_1, aliases=dict(some_alias="ev.something == 1"),
-                counter_weights="an_attribrute")
+                  counter_weights="an_attribrute")
     cutflow_1.apply_description(**config)
     assert len(cutflow_1.selection) == 1
     assert list(cutflow_1.selection.keys()) == ["All"]
@@ -150,7 +150,7 @@ def test_apply_description_1(cutflow_1, selection_dict_1):
 
 def test_apply_description_file(cutflow_1, selection_file):
     config = dict(selection_file=selection_file, aliases=dict(some_alias="ev.something == 1"),
-                counter_weights="an_attribrute")
+                  counter_weights="an_attribrute")
     cutflow_1.apply_description(**config)
     assert len(cutflow_1.selection) == 1
     assert list(cutflow_1.selection.keys()) == ["All"]
@@ -173,7 +173,7 @@ def test_apply_description_raises(cutflow_1, selection_file, selection_dict_1):
 def test_as_rc_pairs(cutflow_1, selection_file):
     from alphatwirl.selection.modules.with_count import AllwCount
     config = dict(selection_file=selection_file, aliases=dict(some_alias="ev.something == 1"),
-                counter_weights="an_attribrute")
+                  counter_weights="an_attribrute")
     cutflow_1.apply_description(**config)
     rc_pairs = cutflow_1.as_rc_pairs()
     assert isinstance(rc_pairs, list)

--- a/test/config/test_cutflow_stage.py
+++ b/test/config/test_cutflow_stage.py
@@ -6,9 +6,35 @@ import alphatwirl_interface.config.cutflow_stage as cfs
 def selection_cut_1():
     return "ev.jet_pt[0] > 0"
 
+
 @pytest.fixture
 def selection_cut_2():
     return "ev.nJet > 1"
+
+
+@pytest.fixture
+def selection_cut_alias():
+    return "some_alias"
+
+
+def test__process_single_selection_1(selection_cut_1):
+    out_selection = cfs._process_single_selection("test__process_single_selection", 
+                                                  selection_cut_1, "ev")
+    assert out_selection == "ev: ev.jet_pt[0] > 0"
+
+
+def test__process_single_selection_alias(selection_cut_alias):
+    aliases = dict(some_alias = "ev.something == 1")
+    out_selection = cfs._process_single_selection("test__process_single_selection_alias",
+                                                  selection_cut_alias, "ev", aliases=aliases)
+    assert out_selection == "ev: ev.something == 1"
+
+
+def test__process_single_selection_raises(selection_cut_alias):
+    name = "test__process_single_selection_raises"
+    with pytest.raises(cfs.BadCutflowConfig) as ex:
+        out_selection = cfs._process_single_selection(name, selection_cut_alias, "ev", aliases={1:"blargwd"})
+    assert "Issue pre-processing selection" in str(ex.value)
 
 
 @pytest.fixture
@@ -16,9 +42,26 @@ def selection_dict_1(selection_cut_1):
     return dict(All=[selection_cut_1, False])
 
 
+def test__prepare_selection_1(selection_dict_1):
+    name = "test__prepare_selection_1"
+    out = cfs._prepare_selection(name, selection_dict_1, "ev")
+    assert len(out) == 1
+    assert out["All"][0] == "ev: ev.jet_pt[0] > 0"
+    assert out["All"][1] == "False"
+
+
 @pytest.fixture
 def selection_dict_2(selection_cut_1, selection_cut_2):
     return dict(All=[selection_cut_1, dict(Any=[selection_cut_2, True])])
+
+
+def test__prepare_selection_2(selection_dict_2):
+    name = "test__prepare_selection_2"
+    out = cfs._prepare_selection(name, selection_dict_2, "ev")
+    assert len(out) == 1
+    assert out["All"][0] == "ev: ev.jet_pt[0] > 0"
+    assert out["All"][1]["Any"][0] == "ev: ev.nJet > 1"
+    assert out["All"][1]["Any"][1] == "True"
 
 
 @pytest.fixture
@@ -26,11 +69,57 @@ def selection_dict_3(selection_cut_1, selection_cut_2):
     return dict(All=[selection_cut_1, dict(Any=dict(Not=selection_cut_2))])
 
 
+def test__prepare_selection_3(selection_dict_3):
+    name = "test__prepare_selection_3"
+    out = cfs._prepare_selection(name, selection_dict_3, "ev")
+    assert len(out) == 1
+    assert out["All"][0] == "ev: ev.jet_pt[0] > 0"
+    assert out["All"][1]["Any"]["Not"] == "ev: ev.nJet > 1"
+    assert len(out["All"][1]) == 1
+    assert len(out["All"][1]["Any"]) == 1
+    assert isinstance(out["All"][1]["Any"], dict)
+
+
+def test__prepare_selection_raises(selection_dict_2):
+    name = "test__prepare_selection_raises"
+    with pytest.raises(cfs.BadCutflowConfig) as ex:
+        cfs._prepare_selection(name, selection_dict_2, "ev", aliases=["not_a", "dict"])
+    assert "aliases is not a dictionary" in str(ex.value)
+
+
+@pytest.fixture
+def selection_file(tmpdir):
+    test_file = tmpdir.join("test_selection_file.yml")
+    test_file.write("""selection: {All: [ "ev.one > 1", "ev.beta == 3" ]}""")
+    return str(test_file)
+
+
+@pytest.fixture
+def selection_file_alias(tmpdir):
+    contents = """selection: {All: [ "ev.one > 1", "ev.beta == 3" ]}\n"""
+    contents += """aliases: {"blah": "ev.random_token > ev.another_token"}"""
+    test_file = tmpdir.join("test_selection_file_alias.yml")
+    test_file.write(contents)
+    return str(test_file)
+
+
+def test__load_selection_file(selection_file):
+    selection, aliases = cfs._load_selection_file(selection_file)
+    assert aliases is None
+    assert len(selection) == 1
+    assert len(selection["All"]) == 2
+
+
+def test__load_selection_file_aliases(selection_file_alias):
+    selection, aliases = cfs._load_selection_file(selection_file_alias)
+    assert isinstance(aliases, dict)
+    assert len(aliases) == 1
+    assert len(selection) == 1
+    assert len(selection["All"]) == 2
+
+
 #def test_apply_description(self, selection_file=None, selection=None, aliases=None,
 #def test_as_rc_pairs(self):
 #def test__create_rc_pairs(self):
 #def test__load_selection_file(selection_file):
-#def test__prepare_selection(stage_name, selection, lambda_arg="ev", aliases=None):
-#def test__recurse_selection(stage_name, selection, lambda_arg="ev", aliases=None):
-#def test__process_single_selection(stage_name, selection, lambda_arg="ev", aliases=None):
 #def test__create_weights(stage_name, weights):

--- a/test/config/test_dict_config.py
+++ b/test/config/test_dict_config.py
@@ -1,0 +1,83 @@
+import pytest
+import alphatwirl_interface.config.dict_config as dict_config
+from alphatwirl_interface.config.binned_df_stage import BinnedDataframe
+from alphatwirl_interface.config.cutflow_stage import CutFlow
+
+
+def test__make_stage_string(tmpdir):
+     stage = dict_config._make_stage(1, tmpdir, "just_a_stage_name", default_type="BinnedDataframe")
+     assert isinstance(stage, BinnedDataframe)
+     assert stage.name == "just_a_stage_name"
+
+
+@pytest.fixture
+def binned_df_cfg():
+    return {"my_first_stage": {"type":  "BinnedDataframe"}}
+
+
+@pytest.fixture
+def cutflow_cfg():
+    return {"my_second_stage": {"type":  "CutFlow"}}
+
+
+def test__make_stage_binned_df(tmpdir, binned_df_cfg):
+    stage = dict_config._make_stage(2, tmpdir, binned_df_cfg)
+    assert isinstance(stage, BinnedDataframe)
+    assert stage.name == "my_first_stage"
+
+
+def test__make_stage_cutflow(tmpdir, cutflow_cfg):
+    stage = dict_config._make_stage(2, tmpdir, cutflow_cfg)
+    assert isinstance(stage, CutFlow)
+    assert stage.name == "my_second_stage"
+
+
+def test__make_stage_raises(tmpdir):
+    with pytest.raises(dict_config.BadStagesDescription) as ex:
+        cfg = {"my_third_stage": {"type":  "bad_stage_type"}}
+        dict_config._make_stage(3, tmpdir, cfg)
+    assert "Unknown type" in str(ex)
+
+    with pytest.raises(dict_config.BadStagesDescription) as ex:
+        cfg = {"my_third_stage": {"type":  "CutFlow"}, 
+               "bad_fourth_stage": {"type":  "BinnedDataframe"}}
+        dict_config._make_stage(4, tmpdir, cfg)
+    assert "More than one key" in str(ex)
+
+
+@pytest.fixture
+def a_stage_list(binned_df_cfg, cutflow_cfg):
+    return [binned_df_cfg, cutflow_cfg, "my_third_stage"]
+
+
+def test__create_stages(a_stage_list, tmpdir):
+     stages = dict_config._create_stages(a_stage_list, tmpdir)
+     assert len(stages) == 3
+     assert isinstance(stages[0], BinnedDataframe)
+     assert isinstance(stages[1], CutFlow)
+     assert isinstance(stages[2], BinnedDataframe)
+
+
+@pytest.fixture
+def all_stage_configs():
+    bins_alpha = {"in": "AlphaT", "out": "alphaT", "bins": dict(nbins=10, low=0, high=2.5)}
+    bins_pt = {"in": "jet_pt", "out": "pt_leadJet", "bins": dict(edges=[0, 20., 100.], overflow=True), "index": 0}
+    bins_region = {"in": "REGION", "out": "region"}
+    weight_dict = dict(none=1, weighted="weight")
+    binned_df_cfg_1 = dict(binning=[bins_pt, bins_region], weights=weight_dict)
+    binned_df_cfg_2 = dict(binning=[bins_alpha], weights=None)
+
+    selection_cut_1 = "ev.jet_pt[0] > 0"
+    selection_cut_2 = "ev.nJet > 1"
+    selection = dict(All=[selection_cut_1, dict(Any=dict(Not=selection_cut_2))])
+    cutflow_cfg = dict(selection=selection, aliases=dict(some_alias="ev.something == 1"), counter_weights="an_attribrute")
+    return dict(my_first_stage=binned_df_cfg_1, my_second_stage=cutflow_cfg, my_third_stage=binned_df_cfg_2)
+
+
+def test__configure_stages(a_stage_list, all_stage_configs, tmpdir):
+    stages = dict_config._create_stages(a_stage_list, tmpdir)
+    dict_config._configure_stages(stages, all_stage_configs)
+
+
+def test_sequence_from_dict(a_stage_list, all_stage_configs, tmpdir):
+    rc_pairs = dict_config.sequence_from_dict(a_stage_list, output_dir=str(tmpdir), **all_stage_configs)

--- a/test/config/test_dict_config.py
+++ b/test/config/test_dict_config.py
@@ -83,4 +83,5 @@ def test__configure_stages(a_stage_list, all_stage_configs, tmpdir):
 
 def test_sequence_from_dict(a_stage_list, all_stage_configs, tmpdir):
     rc_pairs = dict_config.sequence_from_dict(a_stage_list, output_dir=str(tmpdir), **all_stage_configs)
-    assert len(rc_pairs) == 3
+    # 3 stages in list, but one stage makes 2 pairs, so look for 4 rc pairs in total
+    assert len(rc_pairs) == 4

--- a/test/config/test_dict_config.py
+++ b/test/config/test_dict_config.py
@@ -5,19 +5,19 @@ from alphatwirl_interface.config.cutflow_stage import CutFlow
 
 
 def test__make_stage_string(tmpdir):
-     stage = dict_config._make_stage(1, tmpdir, "just_a_stage_name", default_type="BinnedDataframe")
-     assert isinstance(stage, BinnedDataframe)
-     assert stage.name == "just_a_stage_name"
+    stage = dict_config._make_stage(1, tmpdir, "just_a_stage_name", default_type="BinnedDataframe")
+    assert isinstance(stage, BinnedDataframe)
+    assert stage.name == "just_a_stage_name"
 
 
 @pytest.fixture
 def binned_df_cfg():
-    return {"my_first_stage": {"type":  "BinnedDataframe"}}
+    return {"my_first_stage": {"type": "BinnedDataframe"}}
 
 
 @pytest.fixture
 def cutflow_cfg():
-    return {"my_second_stage": {"type":  "CutFlow"}}
+    return {"my_second_stage": {"type": "CutFlow"}}
 
 
 def test__make_stage_binned_df(tmpdir, binned_df_cfg):
@@ -34,13 +34,13 @@ def test__make_stage_cutflow(tmpdir, cutflow_cfg):
 
 def test__make_stage_raises(tmpdir):
     with pytest.raises(dict_config.BadStagesDescription) as ex:
-        cfg = {"my_third_stage": {"type":  "bad_stage_type"}}
+        cfg = {"my_third_stage": {"type": "bad_stage_type"}}
         dict_config._make_stage(3, tmpdir, cfg)
     assert "Unknown type" in str(ex)
 
     with pytest.raises(dict_config.BadStagesDescription) as ex:
-        cfg = {"my_third_stage": {"type":  "CutFlow"}, 
-               "bad_fourth_stage": {"type":  "BinnedDataframe"}}
+        cfg = {"my_third_stage": {"type": "CutFlow"},
+               "bad_fourth_stage": {"type": "BinnedDataframe"}}
         dict_config._make_stage(4, tmpdir, cfg)
     assert "More than one key" in str(ex)
 
@@ -51,11 +51,11 @@ def a_stage_list(binned_df_cfg, cutflow_cfg):
 
 
 def test__create_stages(a_stage_list, tmpdir):
-     stages = dict_config._create_stages(a_stage_list, tmpdir)
-     assert len(stages) == 3
-     assert isinstance(stages[0], BinnedDataframe)
-     assert isinstance(stages[1], CutFlow)
-     assert isinstance(stages[2], BinnedDataframe)
+    stages = dict_config._create_stages(a_stage_list, tmpdir)
+    assert len(stages) == 3
+    assert isinstance(stages[0], BinnedDataframe)
+    assert isinstance(stages[1], CutFlow)
+    assert isinstance(stages[2], BinnedDataframe)
 
 
 @pytest.fixture
@@ -70,7 +70,9 @@ def all_stage_configs():
     selection_cut_1 = "ev.jet_pt[0] > 0"
     selection_cut_2 = "ev.nJet > 1"
     selection = dict(All=[selection_cut_1, dict(Any=dict(Not=selection_cut_2))])
-    cutflow_cfg = dict(selection=selection, aliases=dict(some_alias="ev.something == 1"), counter_weights="an_attribrute")
+    cutflow_cfg = dict(selection=selection,
+                       aliases=dict(some_alias="ev.something == 1"),
+                       counter_weights="an_attribrute")
     return dict(my_first_stage=binned_df_cfg_1, my_second_stage=cutflow_cfg, my_third_stage=binned_df_cfg_2)
 
 
@@ -81,3 +83,4 @@ def test__configure_stages(a_stage_list, all_stage_configs, tmpdir):
 
 def test_sequence_from_dict(a_stage_list, all_stage_configs, tmpdir):
     rc_pairs = dict_config.sequence_from_dict(a_stage_list, output_dir=str(tmpdir), **all_stage_configs)
+    assert len(rc_pairs) == 3

--- a/test/test_selection.py
+++ b/test/test_selection.py
@@ -1,7 +1,7 @@
 import pytest
 
 from alphatwirl_interface import Selection
-from alphatwirl.selection.modules import AllwCount
+from alphatwirl.selection.modules import AllwCount, All
 from alphatwirl.loop import Collector, NullCollector
 from alphatwirl.collector import WriteListToFile
 
@@ -45,7 +45,7 @@ def test_cutflow_file(example_selection_with_cutflow_file):
 def test_no_cutflow_file(example_selection):
     s = example_selection
     assert len(s) == 2
-    assert isinstance(s[0], AllwCount)
+    assert isinstance(s[0], All)
     assert isinstance(s[1], NullCollector)
 
 


### PR DESCRIPTION
Adds a first version of using yaml config files to run the AlphaTwirl sequence (cut-flows, binned DFs).  Still missing the ability to specify producers from this config (ie. scribblers), but will add this in a future PR.  Code includes unit tests.

Using this latest edit would look like:
```python
from alphatwirl_interface.config import read_yaml

# Optional output directory override (can be specified in config file; providing here overrides)
output_dir = "somewhere_over_the_rainbow"
reader_collector_pairs = read_yaml("config.yaml", output_dir)
```