### PR TITLE
Fix all files for pep8 using autopep8

### DIFF
--- a/alphatwirl_interface/heppy/parallel.py
+++ b/alphatwirl_interface/heppy/parallel.py
@@ -67,9 +67,9 @@ def build_parallel_dropbox(parallel_mode, quiet, user_modules, htcondor_job_desc
     else:
         dispatcher = alphatwirl.concurrently.SubprocessRunner()
     workingArea = alphatwirl.concurrently.WorkingArea(
-        dir = tmpdir,
-        python_modules = list(user_modules),
-        exclusions = ["*{}*".format(tmpdir)]
+        dir=tmpdir,
+        python_modules=list(user_modules),
+        exclusions=["*{}*".format(tmpdir)]
     )
     dropbox = alphatwirl.concurrently.TaskPackageDropbox(
         workingArea=workingArea,

--- a/alphatwirl_interface/nanoaod/framework_nanoaod.py
+++ b/alphatwirl_interface/nanoaod/framework_nanoaod.py
@@ -5,7 +5,7 @@ import logging
 
 import alphatwirl
 
-##__________________________________________________________________||
+# __________________________________________________________________||
 import logging
 logger = logging.getLogger(__name__)
 log_handler = logging.StreamHandler(stream=sys.stdout)
@@ -13,11 +13,13 @@ log_formatter = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
 log_handler.setFormatter(log_formatter)
 logger.addHandler(log_handler)
 
-##__________________________________________________________________||
+# __________________________________________________________________||
 from parallel import build_parallel
 from profile_func import profile_func
 
-##__________________________________________________________________||
+# __________________________________________________________________||
+
+
 class FrameworkNanoAOD(object):
     """A simple framework for using alphatwirl
 
@@ -35,25 +37,26 @@ class FrameworkNanoAOD(object):
         profile_out_path (bool): path to store the result of the profile. stdout if None
 
     """
+
     def __init__(self, outdir,
-                 force = False, quiet = False,
-                 parallel_mode = 'multiprocessing',
-                 htcondor_job_desc_extra = [ ],
-                 n_processes = 8,
-                 user_modules = (),
-                 max_events_per_dataset = -1, max_events_per_process = -1,
-                 max_files_per_run = 1,
-                 profile = False, profile_out_path = "prof.txt", #None
-    ):
+                 force=False, quiet=False,
+                 parallel_mode='multiprocessing',
+                 htcondor_job_desc_extra=[],
+                 n_processes=8,
+                 user_modules=(),
+                 max_events_per_dataset=-1, max_events_per_process=-1,
+                 max_files_per_run=1,
+                 profile=False, profile_out_path="prof.txt",  # None
+                 ):
         self.parallel = build_parallel(
-            parallel_mode = parallel_mode,
-            quiet = quiet,
-            n_processes = n_processes,
-            user_modules = user_modules,
-            htcondor_job_desc_extra = htcondor_job_desc_extra,
+            parallel_mode=parallel_mode,
+            quiet=quiet,
+            n_processes=n_processes,
+            user_modules=user_modules,
+            htcondor_job_desc_extra=htcondor_job_desc_extra,
         )
         self.outdir = outdir
-        self.force =  force
+        self.force = force
         self.max_events_per_dataset = max_events_per_dataset
         self.max_events_per_process = max_events_per_process
         self.max_files_per_run = max_files_per_run
@@ -64,7 +67,7 @@ class FrameworkNanoAOD(object):
             reader_collector_pairs,
             components=None,
             tree_name='Events'
-    ):
+            ):
 
         self._begin()
         try:
@@ -138,26 +141,26 @@ class FrameworkNanoAOD(object):
             collector.add(c)
         event_loop_runner = alphatwirl.loop.MPEventLoopRunner(self.parallel.communicationChannel)
         event_builder_config_maker = alphatwirl.nanoaod.EventBuilderConfigMaker(
-            treeName = tree_name,
+            treeName=tree_name,
         )
         dataset_into_event_builders_splitter = alphatwirl.loop.DatasetIntoEventBuildersSplitter(
-            EventBuilder = alphatwirl.nanoaod.EventBuilder,
-            eventBuilderConfigMaker = event_builder_config_maker,
-            maxEvents = self.max_events_per_dataset,
-            maxEventsPerRun = self.max_events_per_process,
-            maxFilesPerRun = self.max_files_per_run,
+            EventBuilder=alphatwirl.nanoaod.EventBuilder,
+            eventBuilderConfigMaker=event_builder_config_maker,
+            maxEvents=self.max_events_per_dataset,
+            maxEventsPerRun=self.max_events_per_process,
+            maxFilesPerRun=self.max_files_per_run,
         )
         event_reader = alphatwirl.loop.EventsInDatasetReader(
-            eventLoopRunner = event_loop_runner,
-            reader = reader,
-            collector = collector,
-            split_into_build_events = dataset_into_event_builders_splitter
+            eventLoopRunner=event_loop_runner,
+            reader=reader,
+            collector=collector,
+            split_into_build_events=dataset_into_event_builders_splitter
         )
         component_readers.add(event_reader)
 
         #if components == ['all']: components = None
         nanoaod_result = alphatwirl.nanoaod.NanoAODResult(
-            component_df = components,
+            component_df=components,
         )
         component_loop = alphatwirl.nanoaod.ComponentLoop(nanoaod_result, component_readers)
 
@@ -167,13 +170,14 @@ class FrameworkNanoAOD(object):
         if not self.profile:
             ret_val = component_loop()
         else:
-            ret_val = profile_func(func = component_loop, profile_out_path = self.profile_out_path)
+            ret_val = profile_func(func=component_loop, profile_out_path=self.profile_out_path)
 
         # Only the last entry in the list of component_readers will be the user-requested data
-        # Other entries are the other tables that we create to help book-keeping, and which are saved to file automatically
+        # Other entries are the other tables that we create to help book-keeping,
+        # and which are saved to file automatically
         return ret_val[-1]
 
     def _end(self):
         self.parallel.end()
 
-##__________________________________________________________________||
+# __________________________________________________________________||

--- a/alphatwirl_interface/nanoaod/framework_nanoaod.py
+++ b/alphatwirl_interface/nanoaod/framework_nanoaod.py
@@ -1,23 +1,15 @@
-# Tai Sakuma <tai.sakuma@cern.ch>
-import os
-import sys
-import logging
-
+from .parallel import build_parallel
+from .profile_func import profile_func
 import alphatwirl
 
-# __________________________________________________________________||
+import os
+import sys
 import logging
 logger = logging.getLogger(__name__)
 log_handler = logging.StreamHandler(stream=sys.stdout)
 log_formatter = logging.Formatter('%(name)s - %(levelname)s - %(message)s')
 log_handler.setFormatter(log_formatter)
 logger.addHandler(log_handler)
-
-# __________________________________________________________________||
-from parallel import build_parallel
-from profile_func import profile_func
-
-# __________________________________________________________________||
 
 
 class FrameworkNanoAOD(object):
@@ -158,7 +150,6 @@ class FrameworkNanoAOD(object):
         )
         component_readers.add(event_reader)
 
-        #if components == ['all']: components = None
         nanoaod_result = alphatwirl.nanoaod.NanoAODResult(
             component_df=components,
         )

--- a/alphatwirl_interface/nanoaod/parallel.py
+++ b/alphatwirl_interface/nanoaod/parallel.py
@@ -24,16 +24,16 @@ class Parallel(object):
         self.communicationChannel.end()
 
 
-def build_parallel(parallel_mode, quiet = True, n_processes = 4, user_modules = [ ], htcondor_job_desc_extra = [ ], **kwargs):
+def build_parallel(parallel_mode, quiet=True, n_processes=4, user_modules=[], htcondor_job_desc_extra=[], **kwargs):
 
     default_parallel_mode = 'multiprocessing'
 
     if parallel_mode in ('subprocess', 'htcondor', 'sge'):
         return build_parallel_dropbox(
-            parallel_mode = parallel_mode,
-            quiet = quiet,
-            user_modules = user_modules,
-            htcondor_job_desc_extra = htcondor_job_desc_extra,
+            parallel_mode=parallel_mode,
+            quiet=quiet,
+            user_modules=user_modules,
+            htcondor_job_desc_extra=htcondor_job_desc_extra,
             **kwargs
         )
 
@@ -43,10 +43,10 @@ def build_parallel(parallel_mode, quiet = True, n_processes = 4, user_modules = 
             parallel_mode, default_parallel_mode
         ))
 
-    return build_parallel_multiprocessing(quiet = quiet, n_processes = n_processes)
+    return build_parallel_multiprocessing(quiet=quiet, n_processes=n_processes)
 
 
-def build_parallel_dropbox(parallel_mode, quiet, user_modules, htcondor_job_desc_extra = [ ], **kwargs):
+def build_parallel_dropbox(parallel_mode, quiet, user_modules, htcondor_job_desc_extra=[], **kwargs):
     tmpdir = '_ccsp_temp'
     user_modules = set(user_modules)
     user_modules.add('alphatwirl_interface')
@@ -62,7 +62,7 @@ def build_parallel_dropbox(parallel_mode, quiet, user_modules, htcondor_job_desc
             progressBar = alphatwirl.progressbar.ProgressPrint()
         progressMonitor = alphatwirl.progressbar.BProgressMonitor(presentation=progressBar)
     if parallel_mode == 'htcondor':
-        dispatcher = alphatwirl.concurrently.HTCondorJobSubmitter(job_desc_extra = htcondor_job_desc_extra)
+        dispatcher = alphatwirl.concurrently.HTCondorJobSubmitter(job_desc_extra=htcondor_job_desc_extra)
     elif parallel_mode == 'sge':
         q = "hep.q" if "queue" not in kwargs else kwargs["queue"]
         t = 10800 if "time" not in kwargs else kwargs["time"]
@@ -70,12 +70,12 @@ def build_parallel_dropbox(parallel_mode, quiet, user_modules, htcondor_job_desc
     else:
         dispatcher = alphatwirl.concurrently.SubprocessRunner()
     workingArea = alphatwirl.concurrently.WorkingArea(
-        dir = tmpdir,
-        python_modules = list(user_modules)
+        dir=tmpdir,
+        python_modules=list(user_modules)
     )
     dropbox = alphatwirl.concurrently.TaskPackageDropbox(
-        workingArea = workingArea,
-        dispatcher = dispatcher
+        workingArea=workingArea,
+        dispatcher=dispatcher
     )
     communicationChannel = alphatwirl.concurrently.CommunicationChannel(dropbox=dropbox)
 
@@ -83,5 +83,6 @@ def build_parallel_dropbox(parallel_mode, quiet, user_modules, htcondor_job_desc
 
 
 def build_parallel_multiprocessing(quiet, n_processes):
-    progressMonitor, communicationChannel = alphatwirl.configure.build_progressMonitor_communicationChannel(quiet = quiet, processes = n_processes)
+    progressMonitor, communicationChannel = alphatwirl.configure.build_progressMonitor_communicationChannel(
+        quiet=quiet, processes=n_processes)
     return Parallel(progressMonitor, communicationChannel)

--- a/alphatwirl_interface/nanoaod/profile_func.py
+++ b/alphatwirl_interface/nanoaod/profile_func.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+
 def profile_func(func, profile_out_path=None):
     import cProfile
     import pstats

--- a/alphatwirl_interface/nanoaod/profile_func.py
+++ b/alphatwirl_interface/nanoaod/profile_func.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
-# Tai Sakuma <tai.sakuma@cern.ch>
-
-# __________________________________________________________________||
-
+from __future__ import print_function
 
 def profile_func(func, profile_out_path=None):
     import cProfile
@@ -17,11 +13,9 @@ def profile_func(func, profile_out_path=None):
     ps = pstats.Stats(pr, stream=s).strip_dirs().sort_stats(sortby)
     ps.print_stats()
     if profile_out_path is None:
-        print s.getvalue()
+        print(s.getvalue())
     else:
         with open(profile_out_path, 'w') as f:
             f.write(s.getvalue())
             f.close()
     return result
-
-# __________________________________________________________________||

--- a/alphatwirl_interface/nanoaod/profile_func.py
+++ b/alphatwirl_interface/nanoaod/profile_func.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python
 # Tai Sakuma <tai.sakuma@cern.ch>
 
-##__________________________________________________________________||
-def profile_func(func, profile_out_path = None):
-    import cProfile, pstats, StringIO
+# __________________________________________________________________||
+
+
+def profile_func(func, profile_out_path=None):
+    import cProfile
+    import pstats
+    import StringIO
     pr = cProfile.Profile()
     pr.enable()
     result = func()
     pr.disable()
     s = StringIO.StringIO()
     sortby = 'cumulative'
-    ps = pstats.Stats(pr, stream = s).strip_dirs().sort_stats(sortby)
+    ps = pstats.Stats(pr, stream=s).strip_dirs().sort_stats(sortby)
     ps.print_stats()
     if profile_out_path is None:
         print s.getvalue()
@@ -20,4 +24,4 @@ def profile_func(func, profile_out_path = None):
             f.close()
     return result
 
-##__________________________________________________________________||
+# __________________________________________________________________||

--- a/alphatwirl_interface/nanoaod/runners.py
+++ b/alphatwirl_interface/nanoaod/runners.py
@@ -1,5 +1,6 @@
 from alphatwirl_interface.nanoaod.framework_nanoaod import FrameworkNanoAOD
 
+
 def build_job_manager(outdir, **kwargs):
     """
     Create a standard nanoAOD job runner, which will process inputs in parallel
@@ -28,7 +29,8 @@ def build_job_manager(outdir, **kwargs):
 
     # http://www.its.hku.hk/services/research/htc/jobsubmission
     # avoid the machines "smXX.hadoop.cluster"
-    # operator '=!=' explained at https://research.cs.wisc.edu/htcondor/manual/v7.8/4_1HTCondor_s_ClassAd.html#ClassAd:evaluation-meta
+    # operator '=!=' explained at
+    # https://research.cs.wisc.edu/htcondor/manual/v7.8/4_1HTCondor_s_ClassAd.html#ClassAd:evaluation-meta
     htcondor_job_desc_extra_blacklist = [
         'requirements=!stringListMember(substr(Target.Machine, 0, 2), "sm,bs")'
     ]
@@ -36,8 +38,8 @@ def build_job_manager(outdir, **kwargs):
     htcondor_job_desc_extra = htcondor_job_desc_extra_request + htcondor_job_desc_extra_blacklist
 
     nanoaod_mgr = FrameworkNanoAOD(
-        outdir = outdir,
-        htcondor_job_desc_extra = htcondor_job_desc_extra,
+        outdir=outdir,
+        htcondor_job_desc_extra=htcondor_job_desc_extra,
         **kwargs
     )
 

--- a/alphatwirl_interface/nanoaod/runners.py
+++ b/alphatwirl_interface/nanoaod/runners.py
@@ -1,4 +1,4 @@
-from alphatwirl_interface.nanoaod.framework_nanoaod import FrameworkNanoAOD
+from .framework_nanoaod import FrameworkNanoAOD
 
 
 def build_job_manager(outdir, **kwargs):
@@ -19,7 +19,8 @@ def build_job_manager(outdir, **kwargs):
     #        'expected_runtime_minutes = 10',
     #        'job_machine_attrs = Machine',
     #        'job_machine_attrs_history_length = 4',
-    #        'requirements = target.machine =!= MachineAttrMachine1 && target.machine =!= MachineAttrMachine2 &&  target.machine =!= MachineAttrMachine3',
+    #        'requirements = target.machine =!= MachineAttrMachine1 && ' +\
+    #        'target.machine =!= MachineAttrMachine2 &&  target.machine =!= MachineAttrMachine3',
     #        'periodic_hold = JobStatus == 2 && CurrentTime - EnteredCurrentStatus > 60 * $(expected_runtime_minutes)',
     #        'periodic_hold_subcode = 1',
     #        'periodic_release = HoldReasonCode == 3 && HoldReasonSubCode == 1 && JobRunCount < 3',


### PR DESCRIPTION
Command was:
```
autopep8 -a --max-line-length 120 -v -i $(flake8  --ignore=F401 --max-line-length=120  |awk  -F: '{names[$1]+=1}END{for(i in names){print i;}}' |tr '\r\n' ' ')
```

Particularly affects the nanoAOD files, and a bit of code in the heppy directory. 